### PR TITLE
Add option to view all users in DAG at once

### DIFF
--- a/app.py
+++ b/app.py
@@ -459,6 +459,7 @@ def create_user_task(i):
 def get_users_in_session(time_stamp, data):
     if data:
         users = [user["name"] for user in data]
+        users = ["All Users"] + users
         return users, users[0]
     return None, None
 
@@ -529,11 +530,18 @@ def update_scheduling_tasks_from_sample(path):
     Input("user-dropdown", "value"),
     Input("session-dags", "data"),
     State("session-users", "data"),
+    prevent_initial_call=True,
 )
 def update_shown_dag(value, dags, users):
     index = None
     if not users:
         return []
+    if value == "All Users":
+        elements = []
+        for _, dag in dags.items():
+            current_dag = DAG(dag, deserialize=True)
+            elements += current_dag.render_state()
+        return elements
     for i, user in enumerate(users):
         if user["name"] == value:
             index = i
@@ -552,7 +560,7 @@ def update_shown_dag(value, dags, users):
         Input("cytoscape-elements-callbacks", "mouseoverNodeData"),
     ],
 )
-def displayTapNodeData(stylesheet, data):
+def displayMouseOverNodeData(stylesheet, data):
     style = {
         "selector": "node",
         "style": {
@@ -571,14 +579,17 @@ def displayTapNodeData(stylesheet, data):
         },
     }
 
-    if data:
-        base_stylesheet = base_cyto_stylesheet
-        style["selector"] = f"node[label = \"{data['label']}\"]"
-        style["style"][
-            "label"
-        ] = f"{data['label']}\nDuration: {data['duration']}\nCPUs: {data['cpus']}\nRAM: {data['ram']}"  # noqa
+    if not data or "parent" not in data:
+        # no need to style compound nodes on hover:
+        return stylesheet
 
-        stylesheet = base_stylesheet + [style]
+    base_stylesheet = base_cyto_stylesheet
+    style["selector"] = f"node[id = \"{data['id']}\"]"
+    style["style"][
+        "label"
+    ] = f"{data['label']}\nDuration: {data['duration']}\nCPUs: {data['cpus']}\nRAM: {data['ram']}"  # noqa
+
+    stylesheet = base_stylesheet + [style]
 
     return stylesheet
 

--- a/src/scheduling.py
+++ b/src/scheduling.py
@@ -124,6 +124,7 @@ class Scheduler:
 
         if "dependencies" in task.props:
             for label, _task in dag.tasks.items():
+                label = label.split(",")[-1]
                 if label in task.props["dependencies"]:
                     if _task.status and _task.status != TaskStatus.FINISHED:
                         logging.info(f"Cannot run {task.id} until {_task.id} finishes")

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -13,7 +13,7 @@ class TestSimpleDag(unittest.TestCase):
         self.assertEqual(self.dag.name, "Test User 1")
 
     def test_dag_nodes(self):
-        self.assertEqual(len(self.dag.nodes), 4)
+        self.assertEqual(len(self.dag.nodes), 5)
 
     def test_dag_edges(self):
         self.assertEqual(len(self.dag.edges), 3)


### PR DESCRIPTION
By default, displays a cytoscape graph that displays all user DAGs at once using cytoscape compound nodes.